### PR TITLE
Fix for accessing the auto casing wordlist too early + improved resou…

### DIFF
--- a/Resources/Designer/MainMenu.xib
+++ b/Resources/Designer/MainMenu.xib
@@ -71,7 +71,7 @@
                                                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                                         <subviews>
                                                                             <outlineView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="firstColumnOnly" selectionHighlightStyle="sourceList" columnReordering="NO" columnResizing="NO" multipleSelection="NO" autosaveColumns="NO" autosaveName="accounts-outline" rowHeight="26" viewBased="YES" floatsGroupRows="NO" indentationPerLevel="14" outlineTableColumn="0ch-yC-d9l" id="I39-Kk-HLZ" userLabel="Accounts Outline" customClass="CategoryOutlineView">
-                                                                                <rect key="frame" x="0.0" y="0.0" width="330" height="594"/>
+                                                                                <rect key="frame" x="0.0" y="0.0" width="330" height="0.0"/>
                                                                                 <autoresizingMask key="autoresizingMask"/>
                                                                                 <color key="backgroundColor" name="_sourceListBackgroundColor" catalog="System" colorSpace="catalog"/>
                                                                                 <color key="gridColor" name="gridColor" catalog="System" colorSpace="catalog"/>
@@ -108,8 +108,8 @@
                                                                                                         <rect key="frame" x="16" y="3" width="16" height="16"/>
                                                                                                         <imageCell key="cell" refusesFirstResponder="YES" imageScaling="proportionallyDown" image="NSActionTemplate" id="5IM-IY-5UN"/>
                                                                                                         <connections>
-                                                                                                            <binding destination="XZ1-Q6-4ar" name="hidden" keyPath="objectValue.loading" id="JqU-LF-01D"/>
                                                                                                             <binding destination="XZ1-Q6-4ar" name="value" keyPath="objectValue.categoryImage" id="TFY-oV-Oit"/>
+                                                                                                            <binding destination="XZ1-Q6-4ar" name="hidden" keyPath="objectValue.loading" id="JqU-LF-01D"/>
                                                                                                         </connections>
                                                                                                     </imageView>
                                                                                                     <progressIndicator wantsLayer="YES" horizontalHuggingPriority="750" verticalHuggingPriority="750" maxValue="100" displayedWhenStopped="NO" bezeled="NO" indeterminate="YES" controlSize="small" style="spinning" translatesAutoresizingMaskIntoConstraints="NO" id="Bd9-PB-D8M" userLabel="Busy Indicator">

--- a/Source/BankingController.m
+++ b/Source/BankingController.m
@@ -253,7 +253,10 @@ static BankingController *bankinControllerInstance;
     [userDefaults addObserver: self forKeyPath: @"colors" options: NSKeyValueObservingOptionInitial context: UserDefaultsBindingContext];
     [userDefaults addObserver: self forKeyPath: @"fontScale" options: NSKeyValueObservingOptionInitial context: UserDefaultsBindingContext];
     [userDefaults addObserver: self forKeyPath: @"showPreliminaryStatements" options: NSKeyValueObservingOptionInitial context: UserDefaultsBindingContext];
-    [userDefaults addObserver: self forKeyPath: @"autoCasing" options: NSKeyValueObservingOptionInitial context: UserDefaultsBindingContext];
+
+    // No initial option for autoCasing which should trigger KVO only when this value actually changes.
+    // Otherwise we do the words.zip update check and the resource manager loading in parallel, without a clear order.
+    [userDefaults addObserver: self forKeyPath: @"autoCasing" options: 0 context: UserDefaultsBindingContext];
     
     [categoryController addObserver: self forKeyPath: @"arrangedObjects.catSum" options: 0 context: nil];
 


### PR DESCRIPTION
…rce loading.

- The observer registered for auto casing must not use an initial KVO call, as this is too early.
- The lock when loading remote resources was too generous, which had especially bad influence when the internet connectivity was lost. The lock is now set only when absolutely necessary.